### PR TITLE
Corrupted encrypted LMDB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,15 +38,18 @@ bincode = "1.3.3"
 # Just benchmarking dependencies
 [target.'cfg(not(target_os = "wasi"))'.dev-dependencies]
 # Pinned to compatibility with MSRV
+argon2 = { version = "0.4.1", features = ["std"] }
+aes = "0.8.4"
+eax = "0.5.0"
+comfy-table = "7.0.1"
 ctrlc = "=3.2.3"
 fastrand = "2.0.0"
-heed = "0.20"
+heed = { path = "../heed/heed", package = "heed3-encryption" }
+libc = "0.2.99"
+rocksdb = "0.22.0"
 sanakirja = "=1.4.1"
 sanakirja-core = "=1.4.1"
 sled = "0.34.7"
-rocksdb = "0.22.0"
-libc = "0.2.99"
-comfy-table = "7.0.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 io-uring = "0.6.2"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@
 [![License](https://img.shields.io/crates/l/redb)](https://crates.io/crates/redb)
 [![dependency status](https://deps.rs/repo/github/cberner/redb/status.svg)](https://deps.rs/repo/github/cberner/redb)
 
+> [!WARNING]
+> This is a fork of the original redb project used to reproduce an LMDB corruption. More information on this corruption can be found [in this tracking issue](https://bugs.openldap.org/show_bug.cgi?id=9920), but essentially, it is a bug in the encryption-at-end feature.
+
+## How to Run this to Trigger the Corruption
+
+You must first need to clone the heed repository and checkout the `combined-lmdb-support` branch (works with https://github.com/meilisearch/heed/tree/ccd61c53862d9256734f4f0324e31b64b5999099).
+
+Clone [the heed repo](https://github.com/meilisearch/heed) with `git clone --recursive` to get the submodules then proceed to replace the `Cargo.toml` to support the encryption feature.
+
+```bash
+cp heed3-encryption/Cargo.toml heed/
+```
+
+Once everything's ready you should be good to go and run the redb benchmarks and observe.
+
+```bash
+rm -r .benchmark
+cargo bench --bench lmdb_benchmark
+```
+
+## Overview
+
 A simple, portable, high-performance, ACID, embedded key-value store.
 
 redb is written in pure Rust and is loosely inspired by [lmdb](http://www.lmdb.tech/doc/). Data is stored in a collection

--- a/benches/int_benchmark.rs
+++ b/benches/int_benchmark.rs
@@ -65,8 +65,16 @@ fn main() {
 
     let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
+        let mut key = eax::Key::<aes::Aes256>::default();
+        argon2::Argon2::default()
+            .hash_password_into(b"Je suis un joyeux dev", b"Ici c'est mon sel", &mut key)
+            .unwrap();
+
+        // We open the environment
+        let mut options =
+            heed::EnvOpenOptions::<eax::Eax<aes::Aes256, eax::aead::consts::U0>>::new_encrypted_with(key);
         let env = unsafe {
-            heed::EnvOpenOptions::new()
+            options
                 .map_size(10 * 4096 * 1024 * 1024)
                 .open(tmpfile.path())
                 .unwrap()

--- a/benches/large_values_benchmark.rs
+++ b/benches/large_values_benchmark.rs
@@ -76,8 +76,15 @@ fn main() {
 
     let lmdb_results = {
         let tmpfile: TempDir = tempfile::tempdir_in(current_dir().unwrap()).unwrap();
+        let mut key = chacha20poly1305::Key::default();
+        argon2::Argon2::default()
+            .hash_password_into(b"Je suis un joyeux dev", b"Ici c'est mon sel", &mut key)
+            .unwrap();
+
+        let mut options =
+            heed::EnvOpenOptions::<chacha20poly1305::ChaCha20Poly1305>::new_encrypted_with(key);
         let env = unsafe {
-            heed::EnvOpenOptions::new()
+            options
                 .map_size(10 * 4096 * 1024 * 1024)
                 .open(tmpfile.path())
                 .unwrap()


### PR DESCRIPTION
> [!WARNING]
> This is a fork of the original redb project used to reproduce an LMDB corruption. More information on this corruption can be found [in this tracking issue](https://bugs.openldap.org/show_bug.cgi?id=9920), but essentially, it is a bug in the encryption-at-end feature.

## How to Run this to Trigger the Corruption

You must first need to clone the heed repository and checkout the `combined-lmdb-support` branch (works with https://github.com/meilisearch/heed/tree/ccd61c53862d9256734f4f0324e31b64b5999099).

Clone [the heed repo](https://github.com/meilisearch/heed) with `git clone --recursive` to get the submodules then proceed to replace the `Cargo.toml` to support the encryption feature.

```bash
cp heed3-encryption/Cargo.toml heed/
```

Once everything's ready you should be good to go and run the redb benchmarks and observe.

```bash
rm -r .benchmark
cargo bench --bench lmdb_benchmark
```